### PR TITLE
Add support for Azure Linux VMs (and maybe fix #8)

### DIFF
--- a/lib/facter/disks.rb
+++ b/lib/facter/disks.rb
@@ -60,9 +60,13 @@ class BlockInfo
     elsif parts.first == "platform" then
       Facter.debug("device #{device} is on a pseudo bus, ignoring")
     else
-      raise "non-pci device #{device}" unless parts.first.start_with?("pci")
+      raise "non-pci device #{device}" unless parts.first =~ /^(pci|LNXSYSTM)/
       driverlink = ["", "sys", "devices", parts.shift]
-      driverlink.concat(parts.take_while { |p| p.match(/^[0-9a-f:.]+$/i) })
+      if driverlink.last.start_with?("pci")
+        driverlink.concat(parts.take_while { |p| p.match(/^[0-9a-f:.]+$/i) })
+      else
+        driverlink.concat(parts.take_while { |p| not p.match(/^host[0-9]/) })
+      end
       driverlink << "driver"
       driverpath = File.readlink(driverlink.join("/"))
       raise "no driver for #{device}" unless driverpath


### PR DESCRIPTION
This restores the `block_devices` fact on Azure (and gets rid of some red) #8 might also magically work too.

I considered changing line [65](https://github.com/CygnusNetworks/cygnus-puppet-disk-facter/compare/master...dannygoulder:master#diff-cf4c11367a728f490e1425ae0c9b2781L65) to match the line in the `else` block on [67-69](https://github.com/CygnusNetworks/cygnus-puppet-disk-facter/compare/master...dannygoulder:master#diff-cf4c11367a728f490e1425ae0c9b2781R67-R69) (it worked in my limited testing) but decided not to risk breaking others.